### PR TITLE
Build for Sailfish Musikloud2

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -53,6 +53,8 @@ symbian {
 
 contains(DEFINES,QSOUNDCLOUD_STATIC_LIBRARY) {
     CONFIG += staticlib
+    headers.path = ../include/qsoundcloud
+    QMAKE_POST_LINK = mkdir -p $$headers.path && cp $$headers.files $$headers.path
 } else {
     CONFIG += create_prl
     INSTALLS += target headers


### PR DESCRIPTION
If we want to get an app which we can put in the store we have to prefix
the shipped qml module with the appname.
See also: https://harbour.jolla.com/faq#QML_API

Please let me know if I should adapt something.
